### PR TITLE
Fix Invalid Type exception

### DIFF
--- a/AndroidCompat/src/main/java/xyz/nulldev/androidcompat/io/sharedprefs/JavaSharedPreferences.kt
+++ b/AndroidCompat/src/main/java/xyz/nulldev/androidcompat/io/sharedprefs/JavaSharedPreferences.kt
@@ -6,7 +6,6 @@ import com.russhwolf.settings.ExperimentalSettingsImplementation
 import com.russhwolf.settings.JvmPreferencesSettings
 import com.russhwolf.settings.serialization.decodeValue
 import com.russhwolf.settings.serialization.encodeValue
-import com.russhwolf.settings.set
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.builtins.SetSerializer
@@ -138,9 +137,12 @@ class JavaSharedPreferences(key: String) : SharedPreferences {
                 @Suppress("UNCHECKED_CAST")
                 when (value) {
                     is Set<*> -> preferences.encodeValue(SetSerializer(String.serializer()), key, value as Set<String>)
-                    else -> {
-                        preferences[key] = value
-                    }
+                    is String -> preferences.putString(key, value)
+                    is Int -> preferences.putInt(key, value)
+                    is Long -> preferences.putLong(key, value)
+                    is Float -> preferences.putFloat(key, value)
+                    is Double -> preferences.putDouble(key, value)
+                    is Boolean -> preferences.putBoolean(key, value)
                 }
             }
         }


### PR DESCRIPTION
T in the `get` extension function was Any, which made it not able to identify what it needed to do. Fixing it was just identifying the type and adding it to the preferences properly after finding that out